### PR TITLE
Add POST /personal/auth/registration/status

### DIFF
--- a/corporate.go
+++ b/corporate.go
@@ -1,7 +1,10 @@
 package monobank
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -16,6 +19,12 @@ type CorporateAPI interface {
 	// Settings returns information about company.
 	// https://api.monobank.ua/docs/corporate.html#tag/Avtorizaciya-ta-nalashtuvannya-kompaniyi/paths/~1personal~1corp~1settings/get
 	Settings(ctx context.Context) (*CorpSettings, error)
+
+	// RegistrationStatus checks whether a corporate-API registration has
+	// been approved by the bank. pubkeyPEM is the PEM-encoded secp256k1
+	// public key originally submitted via /personal/auth/registration.
+	// https://api.monobank.ua/docs/corporate.html#tag/Avtorizaciya-ta-nalashtuvannya-kompaniyi/paths/~1personal~1auth~1registration~1status/post
+	RegistrationStatus(ctx context.Context, pubkeyPEM []byte) (*RegistrationStatusResponse, error)
 
 	// Auth initializes client access.
 	// https://api.monobank.ua/docs/corporate.html#tag/Kliyentski-personalni-dani/paths/~1personal~1auth~1request/post
@@ -109,6 +118,33 @@ func (c CorporateClient) Transactions(ctx context.Context, requestID, accountID 
 	authClient := c.withAuth(c.authMaker.New(requestID))
 
 	return authClient.commonClient.Transactions(ctx, accountID, from, to)
+}
+
+func (c CorporateClient) RegistrationStatus(ctx context.Context, pubkeyPEM []byte) (
+	*RegistrationStatusResponse, error) {
+
+	const urlPath = "/personal/auth/registration/status"
+
+	body, err := json.Marshal(struct {
+		Pubkey string `json:"pubkey"`
+	}{
+		Pubkey: base64.StdEncoding.EncodeToString(pubkeyPEM),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlPath, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	authClient := c.withAuth(c.authMaker.New(""))
+
+	var v RegistrationStatusResponse
+	err = authClient.do(req, &v, http.StatusOK)
+
+	return &v, err
 }
 
 func (c CorporateClient) Settings(ctx context.Context) (*CorpSettings, error) {

--- a/corporate.go
+++ b/corporate.go
@@ -125,9 +125,7 @@ func (c CorporateClient) RegistrationStatus(ctx context.Context, pubkeyPEM []byt
 
 	const urlPath = "/personal/auth/registration/status"
 
-	body, err := json.Marshal(struct {
-		Pubkey string `json:"pubkey"`
-	}{
+	body, err := json.Marshal(RegistrationStatusRequest{
 		Pubkey: base64.StdEncoding.EncodeToString(pubkeyPEM),
 	})
 	if err != nil {

--- a/corporate.go
+++ b/corporate.go
@@ -3,7 +3,6 @@ package monobank
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -125,9 +124,7 @@ func (c CorporateClient) RegistrationStatus(ctx context.Context, pubkeyPEM []byt
 
 	const urlPath = "/personal/auth/registration/status"
 
-	body, err := json.Marshal(RegistrationStatusRequest{
-		Pubkey: base64.StdEncoding.EncodeToString(pubkeyPEM),
-	})
+	body, err := json.Marshal(RegistrationStatusRequest{Pubkey: pubkeyPEM})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal: %w", err)
 	}

--- a/corporate_test.go
+++ b/corporate_test.go
@@ -1,10 +1,17 @@
 package monobank
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/vtopc/go-rest"
 )
 
 // checks that Client satisfies interface
@@ -27,4 +34,48 @@ func TestCorporateClient_withAuth(t *testing.T) {
 	authClient := c.withAuth(auth)
 	assert.Equal(t, auth, authClient.auth)
 	assert.Equal(t, authMaker, authClient.authMaker)
+}
+
+// stubAuth is a no-op Authorizer used by tests that don't care about signing.
+type stubAuth struct{}
+
+func (stubAuth) SetAuth(_ *http.Request) error { return nil }
+
+// stubAuthMaker satisfies CorpAuthMakerAPI without doing any real signing.
+type stubAuthMaker struct{}
+
+func (stubAuthMaker) New(_ string) Authorizer                       { return stubAuth{} }
+func (stubAuthMaker) NewPermissions(_ ...string) Authorizer         { return stubAuth{} }
+
+func TestCorporateClient_RegistrationStatus(t *testing.T) {
+	const pubkeyPEM = "-----BEGIN PUBLIC KEY-----\nABC\n-----END PUBLIC KEY-----\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		hasSuffix(t, r.URL.String(), "/personal/auth/registration/status")
+
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		var got struct {
+			Pubkey string `json:"pubkey"`
+		}
+		require.NoError(t, json.Unmarshal(body, &got))
+		expected := base64.StdEncoding.EncodeToString([]byte(pubkeyPEM))
+		assert.Equal(t, expected, got.Pubkey)
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"Approved","keyId":"abc123"}`))
+	}))
+	defer server.Close()
+
+	c, err := NewCorporateClient(nil, stubAuthMaker{})
+	require.NoError(t, err)
+	c.baseURL = server.URL
+	c.restClient = rest.NewClient(server.Client())
+
+	resp, err := c.RegistrationStatus(context.Background(), []byte(pubkeyPEM))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, RegistrationStatusApproved, resp.Status)
+	assert.Equal(t, "abc123", resp.KeyID)
 }

--- a/corporate_test.go
+++ b/corporate_test.go
@@ -56,15 +56,18 @@ func TestCorporateClient_RegistrationStatus(t *testing.T) {
 
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		var got struct {
-			Pubkey string `json:"pubkey"`
-		}
+		var got RegistrationStatusRequest
 		require.NoError(t, json.Unmarshal(body, &got))
 		expected := base64.StdEncoding.EncodeToString([]byte(pubkeyPEM))
 		assert.Equal(t, expected, got.Pubkey)
 
+		resp, err := json.Marshal(RegistrationStatusResponse{
+			Status: RegistrationStatusApproved,
+			KeyID:  "abc123",
+		})
+		require.NoError(t, err)
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"Approved","keyId":"abc123"}`))
+		_, _ = w.Write(resp)
 	}))
 	defer server.Close()
 

--- a/corporate_test.go
+++ b/corporate_test.go
@@ -2,7 +2,6 @@ package monobank
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -44,8 +43,8 @@ func (stubAuth) SetAuth(_ *http.Request) error { return nil }
 // stubAuthMaker satisfies CorpAuthMakerAPI without doing any real signing.
 type stubAuthMaker struct{}
 
-func (stubAuthMaker) New(_ string) Authorizer                       { return stubAuth{} }
-func (stubAuthMaker) NewPermissions(_ ...string) Authorizer         { return stubAuth{} }
+func (stubAuthMaker) New(_ string) Authorizer               { return stubAuth{} }
+func (stubAuthMaker) NewPermissions(_ ...string) Authorizer { return stubAuth{} }
 
 func TestCorporateClient_RegistrationStatus(t *testing.T) {
 	const pubkeyPEM = "-----BEGIN PUBLIC KEY-----\nABC\n-----END PUBLIC KEY-----\n"
@@ -58,8 +57,7 @@ func TestCorporateClient_RegistrationStatus(t *testing.T) {
 		require.NoError(t, err)
 		var got RegistrationStatusRequest
 		require.NoError(t, json.Unmarshal(body, &got))
-		expected := base64.StdEncoding.EncodeToString([]byte(pubkeyPEM))
-		assert.Equal(t, expected, got.Pubkey)
+		assert.Equal(t, []byte(pubkeyPEM), got.Pubkey)
 
 		resp, err := json.Marshal(RegistrationStatusResponse{
 			Status: RegistrationStatusApproved,

--- a/types.go
+++ b/types.go
@@ -124,9 +124,7 @@ const (
 )
 
 // RegistrationStatusRequest is the body of POST /personal/auth/registration/status.
-// Pubkey is the PEM file containing the secp256k1 public key submitted during
-// registration. encoding/json base64-encodes []byte fields automatically, so
-// the wire format matches the base64 string the bank expects.
+// Pubkey is the PEM file containing the secp256k1 public key submitted during registration.
 type RegistrationStatusRequest struct {
 	Pubkey []byte `json:"pubkey"`
 }

--- a/types.go
+++ b/types.go
@@ -124,10 +124,11 @@ const (
 )
 
 // RegistrationStatusRequest is the body of POST /personal/auth/registration/status.
-// Pubkey is the base64-encoded PEM file containing the secp256k1 public key
-// submitted during registration.
+// Pubkey is the PEM file containing the secp256k1 public key submitted during
+// registration. encoding/json base64-encodes []byte fields automatically, so
+// the wire format matches the base64 string the bank expects.
 type RegistrationStatusRequest struct {
-	Pubkey string `json:"pubkey"`
+	Pubkey []byte `json:"pubkey"`
 }
 
 // RegistrationStatusResponse is the body returned by

--- a/types.go
+++ b/types.go
@@ -113,6 +113,24 @@ type TokenRequest struct {
 	AcceptURL string `json:"acceptUrl"`      // URL to redirect client or build QR on top of it.
 }
 
+// RegistrationStatus is the state of a corporate-API registration request.
+type RegistrationStatus string
+
+// Possible RegistrationStatus values.
+const (
+	RegistrationStatusNew      RegistrationStatus = "New"
+	RegistrationStatusDeclined RegistrationStatus = "Declined"
+	RegistrationStatusApproved RegistrationStatus = "Approved"
+)
+
+// RegistrationStatusResponse is the result of CorporateClient.RegistrationStatus.
+// KeyID is set once mono approves the registration and corresponds to the
+// X-Key-Id the corporate client must use thereafter.
+type RegistrationStatusResponse struct {
+	Status RegistrationStatus `json:"status"`
+	KeyID  string             `json:"keyId"`
+}
+
 type CorpSettings struct {
 	Pubkey     string  `json:"pubkey"`
 	Name       string  `json:"name"`

--- a/types.go
+++ b/types.go
@@ -123,9 +123,17 @@ const (
 	RegistrationStatusApproved RegistrationStatus = "Approved"
 )
 
-// RegistrationStatusResponse is the result of CorporateClient.RegistrationStatus.
-// KeyID is set once mono approves the registration and corresponds to the
-// X-Key-Id the corporate client must use thereafter.
+// RegistrationStatusRequest is the body of POST /personal/auth/registration/status.
+// Pubkey is the base64-encoded PEM file containing the secp256k1 public key
+// submitted during registration.
+type RegistrationStatusRequest struct {
+	Pubkey string `json:"pubkey"`
+}
+
+// RegistrationStatusResponse is the body returned by
+// POST /personal/auth/registration/status. KeyID is set once mono approves
+// the registration and corresponds to the X-Key-Id the corporate client must
+// use thereafter.
 type RegistrationStatusResponse struct {
 	Status RegistrationStatus `json:"status"`
 	KeyID  string             `json:"keyId"`


### PR DESCRIPTION
Closes #36.

Implements `CorporateAPI.RegistrationStatus(ctx, pubkeyPEM)` returning the registration state (`New` / `Declined` / `Approved`) and the assigned `X-Key-Id` once approved.

Per the corp-API spec:
- request body is `{"pubkey": "<base64 of PEM>"}`;
- auth uses the standard `X-Time` + `X-Sign(time | url)` pair without `X-Permissions` or `X-Request-Id`, which is what `CorpAuth` produces when neither is set (`c.authMaker.New("")`).

Includes:

- `RegistrationStatus` type with the three documented statuses as constants.
- `RegistrationStatusResponse` type.
- `httptest`-based test that exercises the full request/response round-trip including the base64 encoding of the PEM.