### PR TITLE
Add CurrencyCode type with ISO 4217 constants

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -1,0 +1,49 @@
+package monobank
+
+import "strconv"
+
+// CurrencyCode is an ISO 4217 numeric currency code. The bank returns it as
+// a plain int in payloads (Account.CurrencyCode, Transaction.CurrencyCode,
+// Jar.CurrencyCode, Currency.CurrencyCodeA/B); callers can convert with
+// monobank.CurrencyCode(t.CurrencyCode) for type-safe comparisons.
+type CurrencyCode int
+
+// Currency codes seen in monobank payloads. Not exhaustive — extend as needed.
+const (
+	UAH CurrencyCode = 980 // Ukrainian hryvnia (account default)
+	USD CurrencyCode = 840 // US dollar
+	EUR CurrencyCode = 978 // Euro
+	GBP CurrencyCode = 826 // Pound sterling
+	PLN CurrencyCode = 985 // Polish złoty
+	CHF CurrencyCode = 756 // Swiss franc
+	JPY CurrencyCode = 392 // Japanese yen
+	CZK CurrencyCode = 203 // Czech koruna
+	CAD CurrencyCode = 124 // Canadian dollar
+	AUD CurrencyCode = 36  // Australian dollar
+	CNY CurrencyCode = 156 // Chinese yuan
+)
+
+// alpha3 maps numeric ISO 4217 codes to their alphabetic counterparts for the
+// currencies declared above.
+var alpha3 = map[CurrencyCode]string{
+	UAH: "UAH",
+	USD: "USD",
+	EUR: "EUR",
+	GBP: "GBP",
+	PLN: "PLN",
+	CHF: "CHF",
+	JPY: "JPY",
+	CZK: "CZK",
+	CAD: "CAD",
+	AUD: "AUD",
+	CNY: "CNY",
+}
+
+// String returns the ISO 4217 alphabetic code (e.g. "UAH") if known, otherwise
+// the numeric code as a decimal string.
+func (c CurrencyCode) String() string {
+	if s, ok := alpha3[c]; ok {
+		return s
+	}
+	return strconv.Itoa(int(c))
+}

--- a/currency_test.go
+++ b/currency_test.go
@@ -1,0 +1,21 @@
+package monobank
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCurrencyCode_String(t *testing.T) {
+	tests := map[CurrencyCode]string{
+		UAH:                "UAH",
+		USD:                "USD",
+		EUR:                "EUR",
+		GBP:                "GBP",
+		PLN:                "PLN",
+		CurrencyCode(7777): "7777", // unknown — falls back to decimal
+	}
+	for code, want := range tests {
+		assert.Equalf(t, want, code.String(), "String() for %d", int(code))
+	}
+}


### PR DESCRIPTION
Adds `monobank.CurrencyCode` (an `int` alias) with named constants for the common ISO 4217 codes mono returns — UAH, USD, EUR, GBP, PLN, CHF, JPY, CZK, CAD, AUD, CNY — and a `String()` method that returns the alphabetic code (falls back to decimal for unknown values).

**Non-breaking**: existing struct fields (`Account.CurrencyCode`, `Transaction.CurrencyCode`, `Jar.CurrencyCode`, `Currency.CurrencyCodeA/B`) keep their plain `int` type. Callers opt in with a cast where they want type-safe comparisons:

```go
if monobank.CurrencyCode(tx.CurrencyCode) == monobank.UAH { ... }
fmt.Println(monobank.CurrencyCode(tx.CurrencyCode)) // "UAH"
```

If the maintainer prefers to switch the struct fields to the new type as a follow-up, that's a one-line change per field plus a CHANGELOG note. I left them as `int` to keep this PR strictly additive.