### PR TITLE
Add functional options for Client

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,52 @@
+package monobank
+
+import (
+	"net/http"
+
+	"github.com/vtopc/go-rest"
+	"github.com/vtopc/go-rest/interceptors"
+)
+
+// Option configures a [Client]. Pass options to [New] to override defaults.
+// Designed to be additive — future options (HTTP retry, timeouts, custom
+// interceptors) slot in without breaking existing callers.
+type Option func(*Client)
+
+// WithHTTPClient sets a custom *http.Client. If not used, the client returned
+// by [defaults.NewHTTPClient] from github.com/vtopc/go-rest is used.
+//
+// Note: monobank requires the Content-Type interceptor; if you bring your own
+// client it will be configured automatically.
+func WithHTTPClient(httpClient *http.Client) Option {
+	return func(c *Client) {
+		if httpClient == nil {
+			return
+		}
+		_ = interceptors.SetReqContentType(httpClient, "application/json")
+		c.restClient = rest.NewClient(httpClient)
+	}
+}
+
+// WithBaseURL overrides the default https://api.monobank.ua base URL.
+// Useful for testing against a recorded server or against monobank's sandbox.
+func WithBaseURL(uri string) Option {
+	return func(c *Client) {
+		c.baseURL = uri
+	}
+}
+
+// New returns a public [Client] built from the supplied options. This is the
+// extensible counterpart to [NewClient] — both produce equivalent clients
+// when given equivalent inputs.
+//
+//	c := monobank.New(
+//	    monobank.WithHTTPClient(myHTTP),
+//	    monobank.WithBaseURL("https://staging.example/"),
+//	)
+func New(opts ...Option) Client {
+	c := NewClient(nil)
+	for _, opt := range opts {
+		opt(&c)
+	}
+	return c
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,48 @@
+package monobank
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew_defaults(t *testing.T) {
+	c := New()
+	assert.Equal(t, baseURL, c.baseURL)
+	assert.NotNil(t, c.restClient)
+	assert.NotNil(t, c.auth)
+}
+
+func TestNew_withBaseURL(t *testing.T) {
+	c := New(WithBaseURL("https://example.test"))
+	assert.Equal(t, "https://example.test", c.baseURL)
+}
+
+func TestNew_withHTTPClient(t *testing.T) {
+	var hits int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	c := New(
+		WithHTTPClient(server.Client()),
+		WithBaseURL(server.URL),
+	)
+
+	_, err := c.Currency(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, hits)
+}
+
+func TestNew_nilHTTPClient_isIgnored(t *testing.T) {
+	// passing a nil http.Client must not panic and must not wipe the default
+	c := New(WithHTTPClient(nil))
+	assert.NotNil(t, c.restClient)
+}


### PR DESCRIPTION
Closes the longstanding `// TODO: add WithOpts` in `client.go`.

Adds a small Functional Options Pattern alongside the existing constructor — strictly additive, no existing API breaks.

```go
// Equivalent calls:
a := monobank.NewClient(myHTTP)
b := monobank.New(monobank.WithHTTPClient(myHTTP))

// New thing the options unlock:
c := monobank.New(
    monobank.WithHTTPClient(myHTTP),
    monobank.WithBaseURL("https://staging.example/"),
)
```

What's added:

- `Option` type (`func(*Client)`).
- `WithHTTPClient(*http.Client) Option` — also wires up the required `application/json` content-type interceptor.
- `WithBaseURL(string) Option` — counterpart to the existing `(*Client).WithBaseURL` method.
- `New(opts ...Option) Client` — public client constructor.

Future options (HTTP retry, timeouts, custom interceptors) slot in here without touching `NewClient`'s signature.

Notes:

- I intentionally didn't touch `NewPersonalClient` / `NewCorporateClient`; happy to add `NewPersonal(opts ...)` / `NewCorporate(opts ..., authMaker)` if you want a consistent surface.
- Did **not** add retry in this PR — that's a behaviour change worth discussing in its own issue (which interceptors, backoff policy, idempotency rules, etc.). The options scaffolding here makes that follow-up trivial.