### PR TITLE
Fix codecov upload

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -31,13 +31,14 @@ jobs:
       - name: Test
         run: make test
 
-# TODO: fix
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v4
-#        with:
-#          files: ./coverage.txt
-#          fail_ci_if_error: true
-#          token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.txt
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # do not break CI if codecov is down or the token is missing on
+          # PRs from forks (where secrets aren't available by design)
+          fail_ci_if_error: false
 
   lint:
     name: lint


### PR DESCRIPTION
Closes #40.

The codecov upload step in `.github/workflows/workflow.yaml` was commented out with a `# TODO: fix` because the original config failed with \`Codecov token not found\`.

Changes:

- Re-enables \`Upload coverage to Codecov\`.
- Bumps \`codecov/codecov-action\` v4 → v5 (current major).
- Sets \`fail_ci_if_error: false\`. Codecov reporting flakes occasionally and PRs from forks don't get access to \`secrets.CODECOV_TOKEN\` by GitHub policy — we don't want CI red over a third-party reporting step.

**Action you'll need to take after merge**: add \`CODECOV_TOKEN\` to repo secrets (Settings → Secrets and variables → Actions). PRs from forks will fall back to v5's tokenless OIDC upload path automatically.