### PR TITLE
test: ServeMux patterns + r.PathValue (Go 1.22)

### DIFF
--- a/servemux_test.go
+++ b/servemux_test.go
@@ -1,0 +1,73 @@
+//go:build go1.22
+
+package monobank
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vtopc/go-rest"
+)
+
+// These tests demonstrate Go 1.22 http.ServeMux method+pattern routing and
+// r.PathValue() against this library's clients. Compared to the existing
+// hasSuffix-based assertions they are strictly stronger:
+//
+//   - a request to a wrong path returns 404 from the mux (rather than being
+//     silently accepted by a catch-all HandlerFunc);
+//   - URL segments are extracted by name instead of being recovered from a
+//     formatted string.
+//
+// The file is build-tagged for go1.22 so this PR does not raise the module's
+// `go 1.16` minimum; CI runs Go 1.23.x and 1.24.x so the tests execute.
+
+func TestClient_Currency_servemuxPattern(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /bank/currency", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`[]`))
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := Client{baseURL: server.URL, restClient: rest.NewClient(server.Client())}
+
+	out, err := c.Currency(context.Background())
+	require.NoError(t, err)
+	assert.NotNil(t, out)
+}
+
+func TestCommonClient_Transactions_pathValues(t *testing.T) {
+	var gotAccount, gotFrom, gotTo string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /personal/statement/{accountID}/{from}/{to}",
+		func(w http.ResponseWriter, r *http.Request) {
+			gotAccount = r.PathValue("accountID")
+			gotFrom = r.PathValue("from")
+			gotTo = r.PathValue("to")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	cc := newCommonClient(server.Client())
+	cc.baseURL = server.URL
+	cc.restClient = rest.NewClient(server.Client())
+
+	from := time.Unix(1700000000, 0)
+	to := time.Unix(1700001000, 0)
+	_, err := cc.Transactions(context.Background(), "acc-123", from, to)
+	require.NoError(t, err)
+
+	assert.Equal(t, "acc-123", gotAccount)
+	assert.Equal(t, strconv.FormatInt(from.Unix(), 10), gotFrom)
+	assert.Equal(t, strconv.FormatInt(to.Unix(), 10), gotTo)
+}


### PR DESCRIPTION
Related to #37 (your link points at \`Request.SetPathValue\`, which is the server-side primitive that powers \`http.ServeMux\` patterns + \`r.PathValue()\` in Go 1.22+).

Since this library is an API client, the natural place to use these features is the existing \`httptest\` machinery — they let us write stronger assertions than the \`hasSuffix\` helper does today:

```go
mux := http.NewServeMux()
mux.HandleFunc("GET /personal/statement/{accountID}/{from}/{to}",
    func(w http.ResponseWriter, r *http.Request) {
        gotAccount := r.PathValue("accountID")        // extract by name
        gotFrom    := r.PathValue("from")
        // wrong method/path → 404 from the mux, no silent acceptance
        ...
    })
```

This PR adds **one new file** (\`servemux_test.go\`) with two illustrative tests:

- \`TestClient_Currency_servemuxPattern\` — method+path matching.
- \`TestCommonClient_Transactions_pathValues\` — extracting URL segments by name.

Existing tests are untouched. The new file is build-tagged \`//go:build go1.22\` so the module's current \`go 1.16\` directive doesn't budge.

**If this isn't what you had in mind for #37**, close at will — it's small enough that I won't be heartbroken. If it is, I'm happy to follow up with a sweep that ports the rest of the \`hasSuffix\` call sites and removes the helper.

**Note on local validation**: I couldn't run these tests on my dev machine because my local Go is a vendor-custom build that has the 1.22 mux patterns stripped out. CI here runs stock Go 1.23.x / 1.24.x where the patterns work as documented — the tests are structurally identical to the existing \`httptest\` ones, only the path-matching layer differs.