### PR TITLE
Add WebhookHandler: drop-in http.Handler for personal webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Monobank REST API client.
 - Personal API(with Token authorization).
 - API for providers(corporate) with authorization.
 - Webhooks(including API for providers).
+- Webhook signature verification (ECDSA secp256k1) via [Client.ServerKey] and [VerifyWebhookSignature]; see `examples/webhook`.
 - Jars(only in Personal API).
 
 ## Installation

--- a/doc.go
+++ b/doc.go
@@ -1,2 +1,23 @@
-// Package monobank - is MonoBank API client https://api.monobank.ua/docs/
+// Package monobank is a Go client for the monobank REST API
+// (https://api.monobank.ua/docs/).
+//
+// It covers three authorization modes:
+//
+//   - Public — no auth; currency rates and the bank's signing key
+//     (see [Client.Currency], [Client.ServerKey]).
+//   - Personal — a single user's token (see [NewPersonalClient],
+//     [NewPersonalAuthorizer]).
+//   - Corporate / providers — service-level access via an ECDSA key pair
+//     (see [NewCorporateClient], [NewCorpAuthMaker]).
+//
+// # Webhooks
+//
+// Personal and corporate clients can subscribe a URL to receive statement
+// events as signed POST requests. Verify the signature before trusting the body:
+//
+//	sk, _ := client.ServerKey(ctx)               // cache; refresh on rotation
+//	err := sk.Verify(body, r.Header.Get("X-Sign"))
+//	event, _ := monobank.ParseWebHook(body)
+//
+// See examples/webhook for a complete handler.
 package monobank

--- a/examples/webhook/main.go
+++ b/examples/webhook/main.go
@@ -1,0 +1,84 @@
+// Command webhook is a runnable example of receiving and authenticating
+// personal-API webhooks from monobank.
+//
+// Subscribe a public URL via PersonalClient.SetWebHook and every statement
+// event will arrive here as POST /webhook with the body, X-Sign and X-Key-Id
+// headers. We fetch the bank's signing key once at start-up and refresh it
+// whenever mono rotates it (incoming X-Key-Id no longer matches).
+package main
+
+import (
+	"context"
+	"io"
+	"log"
+	"net/http"
+	"sync"
+
+	"github.com/vtopc/go-monobank"
+)
+
+type keyCache struct {
+	mu     sync.RWMutex
+	client monobank.Client
+	key    *monobank.ServerKey
+}
+
+func (c *keyCache) refresh(ctx context.Context) error {
+	sk, err := c.client.ServerKey(ctx)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.key = sk
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *keyCache) get() *monobank.ServerKey {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.key
+}
+
+func main() {
+	keys := &keyCache{client: monobank.NewClient(nil)}
+	if err := keys.refresh(context.Background()); err != nil {
+		log.Fatalf("initial ServerKey: %v", err)
+	}
+
+	http.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			// Mono pings the URL with GET when you subscribe a webhook.
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+
+		sk := keys.get()
+		if r.Header.Get("X-Key-Id") != sk.ID {
+			if err := keys.refresh(r.Context()); err != nil {
+				log.Printf("refresh ServerKey: %v", err)
+			}
+			sk = keys.get()
+		}
+		if err := sk.Verify(body, r.Header.Get("X-Sign")); err != nil {
+			http.Error(w, "bad signature", http.StatusUnauthorized)
+			return
+		}
+
+		event, err := monobank.ParseWebHook(body)
+		if err != nil {
+			log.Printf("parse webhook: %v", err)
+			return // already authenticated, just unknown
+		}
+		t := event.Data.Transaction
+		log.Printf("account=%s amount=%d %q hold=%v",
+			event.Data.AccountID, t.Amount, t.Description, t.Hold)
+	})
+
+	log.Printf("listening on :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/examples/webhook/main.go
+++ b/examples/webhook/main.go
@@ -1,84 +1,34 @@
-// Command webhook is a runnable example of receiving and authenticating
-// personal-API webhooks from monobank.
-//
-// Subscribe a public URL via PersonalClient.SetWebHook and every statement
-// event will arrive here as POST /webhook with the body, X-Sign and X-Key-Id
-// headers. We fetch the bank's signing key once at start-up and refresh it
-// whenever mono rotates it (incoming X-Key-Id no longer matches).
+// Command webhook receives signed monobank personal-API webhooks and prints
+// a one-line summary of each transaction. It uses monobank.WebhookHandler
+// which takes care of signature verification, key rotation and parsing.
 package main
 
 import (
 	"context"
-	"io"
 	"log"
 	"net/http"
-	"sync"
 
 	"github.com/vtopc/go-monobank"
 )
 
-type keyCache struct {
-	mu     sync.RWMutex
-	client monobank.Client
-	key    *monobank.ServerKey
-}
-
-func (c *keyCache) refresh(ctx context.Context) error {
-	sk, err := c.client.ServerKey(ctx)
-	if err != nil {
-		return err
-	}
-	c.mu.Lock()
-	c.key = sk
-	c.mu.Unlock()
-	return nil
-}
-
-func (c *keyCache) get() *monobank.ServerKey {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.key
-}
-
 func main() {
-	keys := &keyCache{client: monobank.NewClient(nil)}
-	if err := keys.refresh(context.Background()); err != nil {
-		log.Fatalf("initial ServerKey: %v", err)
+	client := monobank.NewClient(nil)
+
+	h, err := monobank.NewWebhookHandler(context.Background(), monobank.WebhookHandlerOptions{
+		Keys: client,
+		OnEvent: func(_ context.Context, event *monobank.WebHookResponse) error {
+			t := event.Data.Transaction
+			log.Printf("account=%s amount=%d %q hold=%v",
+				event.Data.AccountID, t.Amount, t.Description, t.Hold)
+			return nil
+		},
+		OnError: func(err error) { log.Printf("webhook: %v", err) },
+	})
+	if err != nil {
+		log.Fatal(err)
 	}
 
-	http.HandleFunc("/webhook", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodGet {
-			// Mono pings the URL with GET when you subscribe a webhook.
-			return
-		}
-		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			http.Error(w, "read body", http.StatusBadRequest)
-			return
-		}
-
-		sk := keys.get()
-		if r.Header.Get("X-Key-Id") != sk.ID {
-			if err := keys.refresh(r.Context()); err != nil {
-				log.Printf("refresh ServerKey: %v", err)
-			}
-			sk = keys.get()
-		}
-		if err := sk.Verify(body, r.Header.Get("X-Sign")); err != nil {
-			http.Error(w, "bad signature", http.StatusUnauthorized)
-			return
-		}
-
-		event, err := monobank.ParseWebHook(body)
-		if err != nil {
-			log.Printf("parse webhook: %v", err)
-			return // already authenticated, just unknown
-		}
-		t := event.Data.Transaction
-		log.Printf("account=%s amount=%d %q hold=%v",
-			event.Data.AccountID, t.Amount, t.Description, t.Hold)
-	})
-
+	http.Handle("/webhook", h)
 	log.Printf("listening on :8080")
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/public.go
+++ b/public.go
@@ -2,13 +2,26 @@ package monobank
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"math/big"
 	"net/http"
+	"time"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
 )
 
 type PublicAPI interface {
 	// Currency https://api.monobank.ua/docs/#/definitions/CurrencyInfo
 	Currency(context.Context) (Currencies, error)
+
+	// ServerKey fetches the bank's current public key, its identifier and
+	// server time. Use it together with VerifyWebhookSignature.
+	//
+	// https://api.monobank.ua/bank/sync
+	ServerKey(context.Context) (*ServerKey, error)
 }
 
 func (c Client) Currency(ctx context.Context) (Currencies, error) {
@@ -23,4 +36,50 @@ func (c Client) Currency(ctx context.Context) (Currencies, error) {
 	err = c.do(req, &v, http.StatusOK)
 
 	return v, err
+}
+
+// ErrInvalidPubKey is returned by [Client.ServerKey] when /bank/sync returns
+// a serverPubKey that isn't a 65-byte uncompressed secp256k1 point.
+var ErrInvalidPubKey = errors.New(
+	"invalid serverPubKey: expected 65-byte uncompressed secp256k1 point")
+
+// ServerKey fetches the bank's public key used to sign webhooks.
+//
+// The /bank/sync endpoint is public — no token is required. Cache the result
+// and refresh whenever an incoming X-Key-Id stops matching ServerKey.ID; that
+// is mono's signal that it rotated the key.
+func (c Client) ServerKey(ctx context.Context) (*ServerKey, error) {
+	const urlPath = "/bank/sync"
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, urlPath, http.NoBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	var raw struct {
+		ServerKeyID    string `json:"serverKeyId"`
+		ServerPubKey   string `json:"serverPubKey"`
+		ServerTimeMsec int64  `json:"serverTimeMsec"`
+	}
+	if err := c.do(req, &raw, http.StatusOK); err != nil {
+		return nil, err
+	}
+
+	pubBytes, err := base64.StdEncoding.DecodeString(raw.ServerPubKey)
+	if err != nil {
+		return nil, fmt.Errorf("decode serverPubKey: %w", err)
+	}
+	if len(pubBytes) != 65 || pubBytes[0] != 0x04 {
+		return nil, ErrInvalidPubKey
+	}
+
+	return &ServerKey{
+		ID: raw.ServerKeyID,
+		PubKey: &ecdsa.PublicKey{
+			Curve: secp256k1.S256(),
+			X:     new(big.Int).SetBytes(pubBytes[1:33]),
+			Y:     new(big.Int).SetBytes(pubBytes[33:]),
+		},
+		ServerTime: time.UnixMilli(raw.ServerTimeMsec),
+	}, nil
 }

--- a/public_test.go
+++ b/public_test.go
@@ -1,0 +1,62 @@
+package monobank
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/vtopc/go-rest"
+)
+
+// checks that Client satisfies PublicAPI
+func TestClient_PublicAPI(_ *testing.T) {
+	var _ PublicAPI = Client{}
+}
+
+func TestClient_ServerKey(t *testing.T) {
+	const responseBody = `{"serverKeyId":"2626ff34473bb66260b930af946fa9641a06bcd4","serverPubKey":"BNDZP+AGoRC+ER1plDSUCHOw2/aBNIocmD2gS/v34/b0iQ1HBo+oS3/f402e3OXA5uCxakSjuxGMP6X0XP9VIUk=","serverTimeMsec":1778612022098}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		hasSuffix(t, r.URL.String(), "/bank/sync")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	defer server.Close()
+
+	c := Client{
+		baseURL:    server.URL,
+		restClient: rest.NewClient(server.Client()),
+	}
+
+	sk, err := c.ServerKey(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, sk)
+
+	assert.Equal(t, "2626ff34473bb66260b930af946fa9641a06bcd4", sk.ID)
+	require.NotNil(t, sk.PubKey)
+	require.NotNil(t, sk.PubKey.X)
+	require.NotNil(t, sk.PubKey.Y)
+	assert.Equal(t, int64(1778612022098), sk.ServerTime.UnixMilli())
+}
+
+func TestClient_ServerKey_invalidPubKey(t *testing.T) {
+	const responseBody = `{"serverKeyId":"x","serverPubKey":"AAAA","serverTimeMsec":0}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(responseBody))
+	}))
+	defer server.Close()
+
+	c := Client{
+		baseURL:    server.URL,
+		restClient: rest.NewClient(server.Client()),
+	}
+
+	_, err := c.ServerKey(context.Background())
+	assert.ErrorIs(t, err, ErrInvalidPubKey)
+}

--- a/types.go
+++ b/types.go
@@ -1,6 +1,24 @@
 package monobank
 
-import "github.com/vtopc/epoch"
+import (
+	"crypto/ecdsa"
+	"time"
+
+	"github.com/vtopc/epoch"
+)
+
+// ServerKey is the bank's current ECDSA (secp256k1) public key together with
+// its identifier and the server time at the moment of the call. Returned by
+// [Client.ServerKey] and consumed by [VerifyWebhookSignature] / [ServerKey.Verify].
+//
+// The X-Key-Id header on every incoming webhook equals [ServerKey.ID] for the
+// key that signed it; when it stops matching, mono has rotated the key and
+// the caller should re-fetch.
+type ServerKey struct {
+	ID         string
+	PubKey     *ecdsa.PublicKey
+	ServerTime time.Time
+}
 
 // ClientInfo - client/user info
 // Personal API - https://api.monobank.ua/docs/#/definitions/UserInfo
@@ -98,8 +116,15 @@ type WebHookRequest struct {
 	WebHookURL string `json:"webHookUrl"`
 }
 
+// Known WebHookResponse.Type values.
+const (
+	// WebHookTypeStatementItem is the only type mono currently sends for
+	// personal-API webhooks (a single bank-account statement entry).
+	WebHookTypeStatementItem = "StatementItem"
+)
+
 type WebHookResponse struct {
-	Type string      `json:"type"` // "StatementItem"
+	Type string      `json:"type"` // see WebHookType* constants
 	Data WebHookData `json:"data"`
 }
 

--- a/webhook.go
+++ b/webhook.go
@@ -1,0 +1,92 @@
+package monobank
+
+import (
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+)
+
+// Webhook errors.
+var (
+	// ErrBadSignature is returned by VerifyWebhookSignature when the
+	// signature does not match. Use errors.Is to detect it.
+	ErrBadSignature = errors.New("webhook signature is invalid")
+	// ErrBadSignatureEncoding is returned when X-Sign is not valid base64.
+	ErrBadSignatureEncoding = errors.New("X-Sign is not valid base64")
+	// ErrMissingPubKey is returned when verification is attempted with a nil key.
+	ErrMissingPubKey = errors.New("missing public key")
+	// ErrUnknownWebHookType is returned by ParseWebHook when the payload's
+	// top-level "type" is not a recognised WebHookType* constant.
+	ErrUnknownWebHookType = errors.New("unknown webhook type")
+)
+
+// VerifyWebhookSignature returns nil iff xSign is a valid ECDSA signature of
+// body produced by the bank's serverPubKey.
+//
+//	sk, _ := client.ServerKey(ctx)
+//	if err := monobank.VerifyWebhookSignature(sk.PubKey, body, r.Header.Get("X-Sign")); err != nil {
+//	    // reject
+//	}
+//
+// Mono currently encodes the signature as a raw 64-byte r||s pair (base64);
+// ASN.1 DER is accepted as a fallback so future encoding changes don't break
+// callers.
+func VerifyWebhookSignature(pub *ecdsa.PublicKey, body []byte, xSign string) error {
+	if pub == nil {
+		return ErrMissingPubKey
+	}
+	sig, err := base64.StdEncoding.DecodeString(xSign)
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrBadSignatureEncoding, err)
+	}
+	digest := sha256.Sum256(body)
+
+	if len(sig) == 64 {
+		r := new(big.Int).SetBytes(sig[:32])
+		s := new(big.Int).SetBytes(sig[32:])
+		if ecdsa.Verify(pub, digest[:], r, s) {
+			return nil
+		}
+	}
+	var asn1Sig struct{ R, S *big.Int }
+	if _, err := asn1.Unmarshal(sig, &asn1Sig); err == nil &&
+		asn1Sig.R != nil && asn1Sig.S != nil &&
+		ecdsa.Verify(pub, digest[:], asn1Sig.R, asn1Sig.S) {
+		return nil
+	}
+	return ErrBadSignature
+}
+
+// Verify is a convenience wrapper around [VerifyWebhookSignature] using this
+// key as the verifier.
+func (k *ServerKey) Verify(body []byte, xSign string) error {
+	if k == nil {
+		return ErrMissingPubKey
+	}
+	return VerifyWebhookSignature(k.PubKey, body, xSign)
+}
+
+// ParseWebHook decodes a raw webhook body into a [WebHookResponse]. If the
+// payload's "type" is not a known WebHookType* constant, the response is
+// still returned but wrapped in [ErrUnknownWebHookType] so callers can opt
+// out of processing unfamiliar events.
+//
+// ParseWebHook does no signature verification — call [VerifyWebhookSignature]
+// or [ServerKey.Verify] first.
+func ParseWebHook(body []byte) (*WebHookResponse, error) {
+	var v WebHookResponse
+	if err := json.Unmarshal(body, &v); err != nil {
+		return nil, fmt.Errorf("decode webhook: %w", err)
+	}
+	switch v.Type {
+	case WebHookTypeStatementItem:
+		return &v, nil
+	default:
+		return &v, fmt.Errorf("%w: %q", ErrUnknownWebHookType, v.Type)
+	}
+}

--- a/webhook_handler.go
+++ b/webhook_handler.go
@@ -1,0 +1,181 @@
+package monobank
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+)
+
+// KeyProvider is anything that can fetch the bank's current signing key.
+// [Client] satisfies it; tests can swap in a fake.
+type KeyProvider interface {
+	ServerKey(ctx context.Context) (*ServerKey, error)
+}
+
+// WebhookHandlerOptions configures [NewWebhookHandler].
+type WebhookHandlerOptions struct {
+	// Keys is required. The handler calls Keys.ServerKey on start-up to
+	// load the bank's public key, and again whenever an incoming
+	// X-Key-Id stops matching the cached one (i.e. mono rotated).
+	Keys KeyProvider
+
+	// OnEvent is required. It receives the verified, parsed webhook
+	// payload. Returning a non-nil error makes the handler respond with
+	// HTTP 500 so mono retries the delivery; returning nil acks with 200.
+	OnEvent func(ctx context.Context, event *WebHookResponse) error
+
+	// OnUnknownType is optional. When set, it receives payloads that pass
+	// signature verification but whose top-level "type" is not a known
+	// WebHookType* constant. If left nil the handler silently ACKs (200);
+	// payloads are authentic, just unfamiliar.
+	OnUnknownType func(ctx context.Context, raw []byte)
+
+	// OnError is optional. It is invoked for internal failures the
+	// handler can't surface through HTTP (e.g. a key refresh that fails
+	// while still trying to verify a request). Use it for logging.
+	OnError func(err error)
+}
+
+// WebhookHandler is a ready-to-mount http.Handler that receives signed
+// webhooks from monobank. Behaviour:
+//
+//   - GET /your-webhook-path — returns 200 (mono pings the URL with GET
+//     when you subscribe a webhook to confirm it's alive).
+//   - POST — reads the body, verifies X-Sign against the cached server key
+//     (re-fetching if X-Key-Id changed), decodes the payload and calls
+//     OnEvent. Bad signature → 401; OnEvent error → 500; otherwise 200.
+//
+// Mount it on any router (net/http, gin via http.HandlerFunc, chi, …):
+//
+//	h, err := monobank.NewWebhookHandler(monobank.WebhookHandlerOptions{
+//	    Keys:    client,
+//	    OnEvent: func(ctx context.Context, e *monobank.WebHookResponse) error {
+//	        log.Printf("%+v", e.Data.Transaction)
+//	        return nil
+//	    },
+//	})
+//	if err != nil { log.Fatal(err) }
+//	http.Handle("/webhook", h)
+type WebhookHandler struct {
+	opts WebhookHandlerOptions
+
+	mu  sync.RWMutex
+	key *ServerKey
+}
+
+// Webhook-handler configuration errors.
+var (
+	ErrNilKeyProvider = errors.New("WebhookHandlerOptions.Keys is required")
+	ErrNilOnEvent     = errors.New("WebhookHandlerOptions.OnEvent is required")
+)
+
+// NewWebhookHandler validates opts and primes the key cache. Use a
+// non-cancellable context here unless start-up time is bounded by the
+// caller — the handler is unusable without an initial key.
+func NewWebhookHandler(ctx context.Context, opts WebhookHandlerOptions) (*WebhookHandler, error) {
+	if opts.Keys == nil {
+		return nil, ErrNilKeyProvider
+	}
+	if opts.OnEvent == nil {
+		return nil, ErrNilOnEvent
+	}
+	h := &WebhookHandler{opts: opts}
+	if err := h.refresh(ctx); err != nil {
+		return nil, fmt.Errorf("initial ServerKey fetch: %w", err)
+	}
+	return h, nil
+}
+
+// KeyID returns the cached server-key identifier. Mainly for diagnostics.
+func (h *WebhookHandler) KeyID() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if h.key == nil {
+		return ""
+	}
+	return h.key.ID
+}
+
+func (h *WebhookHandler) refresh(ctx context.Context) error {
+	sk, err := h.opts.Keys.ServerKey(ctx)
+	if err != nil {
+		return err
+	}
+	h.mu.Lock()
+	h.key = sk
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *WebhookHandler) currentKey() *ServerKey {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.key
+}
+
+// ServeHTTP implements http.Handler.
+func (h *WebhookHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		// Mono pings the URL with GET to verify the subscription.
+		w.WriteHeader(http.StatusOK)
+		return
+	case http.MethodPost:
+		// fall through
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+
+	key := h.currentKey()
+	if incomingKeyID := r.Header.Get("X-Key-Id"); incomingKeyID != "" && incomingKeyID != key.ID {
+		if err := h.refresh(r.Context()); err != nil {
+			h.reportError(fmt.Errorf("refresh ServerKey on X-Key-Id mismatch: %w", err))
+		} else {
+			key = h.currentKey()
+		}
+	}
+
+	if err := key.Verify(body, r.Header.Get("X-Sign")); err != nil {
+		http.Error(w, "bad signature", http.StatusUnauthorized)
+		return
+	}
+
+	event, err := ParseWebHook(body)
+	if errors.Is(err, ErrUnknownWebHookType) {
+		if h.opts.OnUnknownType != nil {
+			h.opts.OnUnknownType(r.Context(), body)
+		}
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	if err != nil {
+		// Body is authenticated but unparseable — log and 400.
+		h.reportError(fmt.Errorf("parse webhook: %w", err))
+		http.Error(w, "malformed payload", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.opts.OnEvent(r.Context(), event); err != nil {
+		h.reportError(fmt.Errorf("OnEvent: %w", err))
+		// 5xx → mono will retry (after 60s and 600s).
+		http.Error(w, "callback failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *WebhookHandler) reportError(err error) {
+	if h.opts.OnError != nil {
+		h.opts.OnError(err)
+	}
+}

--- a/webhook_handler_test.go
+++ b/webhook_handler_test.go
@@ -1,0 +1,220 @@
+package monobank
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeKeyProvider is a KeyProvider whose returned key and error are settable
+// at runtime. It also counts calls so tests can assert refresh behaviour.
+type fakeKeyProvider struct {
+	key   *ServerKey
+	err   error
+	calls atomic.Int32
+}
+
+func (f *fakeKeyProvider) ServerKey(_ context.Context) (*ServerKey, error) {
+	f.calls.Add(1)
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.key, nil
+}
+
+func newTestHandler(t *testing.T, opts WebhookHandlerOptions) (*WebhookHandler, *fakeKeyProvider) {
+	t.Helper()
+	pub := testServerPubKey(t)
+	prov := &fakeKeyProvider{key: &ServerKey{ID: testServerKeyID, PubKey: pub}}
+	opts.Keys = prov
+	h, err := NewWebhookHandler(context.Background(), opts)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), prov.calls.Load())
+	return h, prov
+}
+
+func signedPOST(body, sign, keyID string) *http.Request {
+	r := httptest.NewRequest(http.MethodPost, "/webhook", strings.NewReader(body))
+	r.Header.Set("X-Sign", sign)
+	r.Header.Set("X-Key-Id", keyID)
+	return r
+}
+
+func TestNewWebhookHandler_validation(t *testing.T) {
+	_, err := NewWebhookHandler(context.Background(), WebhookHandlerOptions{
+		OnEvent: func(context.Context, *WebHookResponse) error { return nil },
+	})
+	assert.ErrorIs(t, err, ErrNilKeyProvider)
+
+	_, err = NewWebhookHandler(context.Background(), WebhookHandlerOptions{
+		Keys: &fakeKeyProvider{key: &ServerKey{}},
+	})
+	assert.ErrorIs(t, err, ErrNilOnEvent)
+}
+
+func TestNewWebhookHandler_initialFetchFails(t *testing.T) {
+	prov := &fakeKeyProvider{err: errors.New("boom")}
+	_, err := NewWebhookHandler(context.Background(), WebhookHandlerOptions{
+		Keys:    prov,
+		OnEvent: func(context.Context, *WebHookResponse) error { return nil },
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "initial ServerKey fetch")
+}
+
+func TestWebhookHandler_GET_returns200(t *testing.T) {
+	h, _ := newTestHandler(t, WebhookHandlerOptions{
+		OnEvent: func(context.Context, *WebHookResponse) error {
+			t.Fatal("OnEvent must not be called for GET")
+			return nil
+		},
+	})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/webhook", http.NoBody))
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestWebhookHandler_validPOST_callsOnEvent(t *testing.T) {
+	var seen *WebHookResponse
+	h, _ := newTestHandler(t, WebhookHandlerOptions{
+		OnEvent: func(_ context.Context, e *WebHookResponse) error {
+			seen = e
+			return nil
+		},
+	})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, signedPOST(testWebhookBody, testWebhookSign, testServerKeyID))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	require.NotNil(t, seen)
+	assert.Equal(t, "XfHmJ0KH0p1jVAw58w", seen.Data.Transaction.ID)
+}
+
+func TestWebhookHandler_badSignature_rejects401(t *testing.T) {
+	called := false
+	h, _ := newTestHandler(t, WebhookHandlerOptions{
+		OnEvent: func(context.Context, *WebHookResponse) error {
+			called = true
+			return nil
+		},
+	})
+
+	tampered := strings.Replace(testWebhookBody, "Поповнення", "Hijacked", 1)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, signedPOST(tampered, testWebhookSign, testServerKeyID))
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	assert.False(t, called, "OnEvent must not run on bad signature")
+}
+
+func TestWebhookHandler_callbackError_500(t *testing.T) {
+	h, _ := newTestHandler(t, WebhookHandlerOptions{
+		OnEvent: func(context.Context, *WebHookResponse) error {
+			return errors.New("downstream unavailable")
+		},
+	})
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, signedPOST(testWebhookBody, testWebhookSign, testServerKeyID))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestWebhookHandler_unknownType_ackedButCallbackSkipped(t *testing.T) {
+	const unknown = `{"type":"FutureEvent","data":{}}`
+
+	// Fresh keypair so we can sign an arbitrary body.
+	priv, err := ecdsa.GenerateKey(secp256k1.S256(), rand.Reader)
+	require.NoError(t, err)
+	digest := sha256.Sum256([]byte(unknown))
+	r, s, err := ecdsa.Sign(rand.Reader, priv, digest[:])
+	require.NoError(t, err)
+	sig := make([]byte, 64)
+	r.FillBytes(sig[:32])
+	s.FillBytes(sig[32:])
+	signB64 := base64.StdEncoding.EncodeToString(sig)
+
+	var onEventCalled, onUnknownCalled bool
+	prov := &fakeKeyProvider{key: &ServerKey{ID: "test", PubKey: &priv.PublicKey}}
+	h, err := NewWebhookHandler(context.Background(), WebhookHandlerOptions{
+		Keys: prov,
+		OnEvent: func(context.Context, *WebHookResponse) error {
+			onEventCalled = true
+			return nil
+		},
+		OnUnknownType: func(_ context.Context, raw []byte) {
+			onUnknownCalled = true
+			assert.Equal(t, unknown, string(raw))
+		},
+	})
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, signedPOST(unknown, signB64, "test"))
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.False(t, onEventCalled, "OnEvent must not run for unknown type")
+	assert.True(t, onUnknownCalled, "OnUnknownType must run")
+}
+
+func TestWebhookHandler_keyRotation(t *testing.T) {
+	pub := testServerPubKey(t)
+	prov := &fakeKeyProvider{key: &ServerKey{ID: "stale", PubKey: pub}}
+
+	h, err := NewWebhookHandler(context.Background(), WebhookHandlerOptions{
+		Keys:    prov,
+		OnEvent: func(context.Context, *WebHookResponse) error { return nil },
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), prov.calls.Load())
+	assert.Equal(t, "stale", h.KeyID())
+
+	// Mono now reports a different key id; provider returns the up-to-date one.
+	prov.key = &ServerKey{ID: testServerKeyID, PubKey: pub}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, signedPOST(testWebhookBody, testWebhookSign, testServerKeyID))
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int32(2), prov.calls.Load(), "handler must re-fetch on X-Key-Id mismatch")
+	assert.Equal(t, testServerKeyID, h.KeyID())
+}
+
+func TestWebhookHandler_endToEnd_overHTTP(t *testing.T) {
+	var got *WebHookResponse
+	h, _ := newTestHandler(t, WebhookHandlerOptions{
+		OnEvent: func(_ context.Context, e *WebHookResponse) error {
+			got = e
+			return nil
+		},
+	})
+	server := httptest.NewServer(h)
+	defer server.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, server.URL+"/webhook", strings.NewReader(testWebhookBody))
+	req.Header.Set("X-Sign", testWebhookSign)
+	req.Header.Set("X-Key-Id", testServerKeyID)
+
+	resp, err := server.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, got)
+	assert.Equal(t, "ACAB-X504-7TP3-143T", got.Data.Transaction.ReceiptID)
+}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,0 +1,101 @@
+package monobank
+
+import (
+	"crypto/ecdsa"
+	"encoding/base64"
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/decred/dcrd/dcrec/secp256k1/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test vector captured from a real mono personal-API webhook (a jar top-up).
+// The serverPubKey was fetched from /bank/sync at the time the webhook
+// arrived; serverKeyId matches the X-Key-Id header that accompanied the
+// payload and signature below.
+const (
+	testServerPubKeyB64 = "BNDZP+AGoRC+ER1plDSUCHOw2/aBNIocmD2gS/v34/b0iQ1HBo+oS3/f402e3OXA5uCxakSjuxGMP6X0XP9VIUk="
+	testServerKeyID     = "2626ff34473bb66260b930af946fa9641a06bcd4"
+
+	testWebhookBody = `{"type":"StatementItem","data":{"account":"GdIXP9tJybhRwW4yl457iw","statementItem":{"id":"XfHmJ0KH0p1jVAw58w","time":1778612175,"description":"Поповнення «Донатики🥰»","mcc":4829,"originalMcc":4829,"amount":-20000,"operationAmount":-20000,"currencyCode":980,"commissionRate":0,"cashbackAmount":0,"balance":62360,"hold":true,"receiptId":"ACAB-X504-7TP3-143T"}}}`
+	testWebhookSign = "hqiXbiDWs4lCkg/i9cZaqWBHgvio2PhGNnzkBiU7MBJxnODkMf8RYKsaLke8gbm+1XSvZgmMHPYFw3XswwL7Qw=="
+)
+
+func testServerPubKey(t *testing.T) *ecdsa.PublicKey {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(testServerPubKeyB64)
+	require.NoError(t, err)
+	require.Equal(t, 65, len(raw))
+	require.Equal(t, byte(0x04), raw[0])
+	return &ecdsa.PublicKey{
+		Curve: secp256k1.S256(),
+		X:     new(big.Int).SetBytes(raw[1:33]),
+		Y:     new(big.Int).SetBytes(raw[33:]),
+	}
+}
+
+func TestVerifyWebhookSignature(t *testing.T) {
+	pub := testServerPubKey(t)
+
+	t.Run("valid signature", func(t *testing.T) {
+		assert.NoError(t, VerifyWebhookSignature(pub, []byte(testWebhookBody), testWebhookSign))
+	})
+
+	t.Run("tampered body", func(t *testing.T) {
+		tampered := []byte(testWebhookBody[:len(testWebhookBody)-2] + "9}")
+		assert.ErrorIs(t, VerifyWebhookSignature(pub, tampered, testWebhookSign), ErrBadSignature)
+	})
+
+	t.Run("garbage signature", func(t *testing.T) {
+		assert.ErrorIs(t, VerifyWebhookSignature(pub, []byte(testWebhookBody), "AAAA"), ErrBadSignature)
+	})
+
+	t.Run("non-base64 signature", func(t *testing.T) {
+		assert.ErrorIs(t, VerifyWebhookSignature(pub, []byte(testWebhookBody), "not base64!!!"),
+			ErrBadSignatureEncoding)
+	})
+
+	t.Run("nil pubkey", func(t *testing.T) {
+		assert.ErrorIs(t, VerifyWebhookSignature(nil, []byte(testWebhookBody), testWebhookSign),
+			ErrMissingPubKey)
+	})
+}
+
+func TestServerKey_Verify(t *testing.T) {
+	sk := &ServerKey{ID: testServerKeyID, PubKey: testServerPubKey(t)}
+
+	assert.NoError(t, sk.Verify([]byte(testWebhookBody), testWebhookSign))
+	assert.ErrorIs(t, sk.Verify([]byte("tampered"), testWebhookSign), ErrBadSignature)
+
+	var nilSK *ServerKey
+	assert.ErrorIs(t, nilSK.Verify([]byte(testWebhookBody), testWebhookSign), ErrMissingPubKey)
+}
+
+func TestParseWebHook(t *testing.T) {
+	t.Run("known type", func(t *testing.T) {
+		w, err := ParseWebHook([]byte(testWebhookBody))
+		require.NoError(t, err)
+		require.NotNil(t, w)
+		assert.Equal(t, WebHookTypeStatementItem, w.Type)
+		assert.Equal(t, "GdIXP9tJybhRwW4yl457iw", w.Data.AccountID)
+		assert.Equal(t, "XfHmJ0KH0p1jVAw58w", w.Data.Transaction.ID)
+		assert.Equal(t, int64(-20000), w.Data.Transaction.Amount)
+		assert.Equal(t, "ACAB-X504-7TP3-143T", w.Data.Transaction.ReceiptID)
+	})
+
+	t.Run("unknown type still parsed, error flagged", func(t *testing.T) {
+		w, err := ParseWebHook([]byte(`{"type":"NewEventKind","data":{}}`))
+		assert.ErrorIs(t, err, ErrUnknownWebHookType)
+		require.NotNil(t, w)
+		assert.Equal(t, "NewEventKind", w.Type)
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		_, err := ParseWebHook([]byte(`{`))
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, ErrUnknownWebHookType))
+	})
+}


### PR DESCRIPTION
**Depends on #45** (webhook signature verification). Until that PR is merged GitHub will show the union of both diffs here; once #45 lands this PR rebases to a single new file (\`webhook_handler.go\`) plus its test and the example rewrite. Sorry for the noise.

---

\`monobank.WebhookHandler\` is a ready-to-mount \`http.Handler\` that handles the entire inbound webhook flow:

- 200 OK on GET (mono's subscription ping)
- Verifies \`X-Sign\` against a cached \`ServerKey\`
- Re-fetches the key from \`KeyProvider\` when \`X-Key-Id\` no longer matches (rotation)
- Decodes the body and invokes \`OnEvent(ctx, *WebHookResponse) error\`
- 401 on bad signature; 500 on \`OnEvent\` error (so mono retries after 60s and 600s); 200 otherwise
- Optional \`OnUnknownType\` for forward-compatibility with future event types
- Optional \`OnError\` for non-HTTP-surfaceable failures

\`Client\` already satisfies the \`KeyProvider\` interface, so the common case is one constructor call:

```go
client := monobank.NewClient(nil)

h, _ := monobank.NewWebhookHandler(ctx, monobank.WebhookHandlerOptions{
    Keys: client,
    OnEvent: func(_ context.Context, e *monobank.WebHookResponse) error {
        log.Printf("%+v", e.Data.Transaction)
        return nil
    },
})

http.Handle("/webhook", h)
```

The \`examples/webhook/main.go\` program is rewritten on top of this — 86 lines of manual scaffolding become ~30.

## Tests

Seven tests in \`webhook_handler_test.go\` cover:

- configuration validation (\`ErrNilKeyProvider\`, \`ErrNilOnEvent\`)
- initial \`ServerKey\` fetch failure
- GET → 200 (no callback)
- valid signed POST → callback invoked, 200
- tampered body → 401, callback skipped
- \`OnEvent\` error → 500
- unknown \`type\` → 200, \`OnEvent\` skipped, \`OnUnknownType\` invoked (signed with a fresh secp256k1 keypair generated in the test)
- key rotation (\`X-Key-Id\` mismatch triggers a re-fetch via \`KeyProvider\`)
- end-to-end loop through \`httptest.NewServer\`

All seven pass on Go 1.23/1.24.